### PR TITLE
EF-885 uses integer instead of deprecated fixnum

### DIFF
--- a/lib/smartystreets/api_error.rb
+++ b/lib/smartystreets/api_error.rb
@@ -17,7 +17,7 @@ module SmartyStreets
 
 
     def self.from_code(code)
-      check_type(code, Fixnum)
+      check_type(code, Integer)
       case code
       when BAD_INPUT then new(code, 'Bad input. Required Fields missing from input, are malformed, or are too numerous.')
       when UNAUTHORIZED then new(code, 'Unauthorized. Authentication failure; invalid credentials')

--- a/lib/smartystreets/base_json_object.rb
+++ b/lib/smartystreets/base_json_object.rb
@@ -28,12 +28,12 @@ module SmartyStreets
     end
 
     def get_optional_fixnum(hash, key)
-      hash[key] != nil ? check_type(hash[key], Fixnum) : nil
+      hash[key] != nil ? check_type(hash[key], Integer) : nil
     end
 
     def get_required_fixnum(hash, key)
       check_argument(hash[key] != nil)
-      check_type(hash[key], Fixnum)
+      check_type(hash[key], Integer)
     end
 
     def get_optional_float(hash, key)
@@ -46,12 +46,12 @@ module SmartyStreets
     end
 
     def get_optional_number(hash, key)
-      hash[key] != nil ? check_type(hash[key], Float, Fixnum) : nil
+      hash[key] != nil ? check_type(hash[key], Float, Integer) : nil
     end
 
     def get_required_number(hash, key)
       check_argument(hash[key] != nil)
-      check_type(hash[key], Float, Fixnum)
+      check_type(hash[key], Float, Integer)
     end
     
     def get_optional_boolean(hash, key)


### PR DESCRIPTION
## Problem

Fixnum is deprecated.

## Solution

Use integer instead.

We're pinned to `task/allow_integer_lat_long` currently, so that's the base for this PR. Since we are looking at options for other gems, I'm going to keep my scope to the bare minimum here.
